### PR TITLE
Add time of matching scene to response + gif to supported image extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ I've tested these:
 - png
 - jfif
 - webp
+- gif
 
 If you have found other's working formats please create an issue
 

--- a/cli/file_search.go
+++ b/cli/file_search.go
@@ -73,6 +73,8 @@ func SearchByImageFile(imagePath string) {
 	fmt.Print("📊 Similarity: ")
 	helpers.PrintAnimeSimilarity(strconv.FormatFloat(animeResp.Docs[0].Similarity, 'f', 6, 64))
 	fmt.Println("📺 Episode Number: " + color.MagentaString(strconv.Itoa(animeResp.Docs[0].Episode)))
+	fmt.Print("⌚ Scene At: " )
+	helpers.PrintSceneAt(animeResp.Docs[0].At)
 	fmt.Println("📅 Year & Season: " + color.CyanString(animeResp.Docs[0].Season))
 	fmt.Print("🍓 Is Adult: ")
 	helpers.PrintIsAdult(animeResp.Docs[0].IsAdult)

--- a/cli/file_search.go
+++ b/cli/file_search.go
@@ -73,7 +73,7 @@ func SearchByImageFile(imagePath string) {
 	fmt.Print("📊 Similarity: ")
 	helpers.PrintAnimeSimilarity(strconv.FormatFloat(animeResp.Docs[0].Similarity, 'f', 6, 64))
 	fmt.Println("📺 Episode Number: " + color.MagentaString(strconv.Itoa(animeResp.Docs[0].Episode)))
-	fmt.Print("⌚ Scene At: " )
+	fmt.Print("⌚ Scene At: ")
 	helpers.PrintSceneAt(animeResp.Docs[0].At)
 	fmt.Println("📅 Year & Season: " + color.CyanString(animeResp.Docs[0].Season))
 	fmt.Print("🍓 Is Adult: ")

--- a/cli/link_search.go
+++ b/cli/link_search.go
@@ -61,6 +61,8 @@ func SearchByImageLink(imageLink string) {
 	fmt.Print("📊 Similarity: ")
 	helpers.PrintAnimeSimilarity(strconv.FormatFloat(animeResp.Docs[0].Similarity, 'f', 6, 64))
 	fmt.Println("📺 Episode Number: " + color.MagentaString(strconv.Itoa(animeResp.Docs[0].Episode)))
+	fmt.Print("⌚ Scene At: " )
+	helpers.PrintSceneAt(animeResp.Docs[0].At)
 	fmt.Println("📅 Year & Season: " + color.CyanString(animeResp.Docs[0].Season))
 	fmt.Print("🍓 Is Adult: ")
 	helpers.PrintIsAdult(animeResp.Docs[0].IsAdult)

--- a/cli/link_search.go
+++ b/cli/link_search.go
@@ -61,7 +61,7 @@ func SearchByImageLink(imageLink string) {
 	fmt.Print("📊 Similarity: ")
 	helpers.PrintAnimeSimilarity(strconv.FormatFloat(animeResp.Docs[0].Similarity, 'f', 6, 64))
 	fmt.Println("📺 Episode Number: " + color.MagentaString(strconv.Itoa(animeResp.Docs[0].Episode)))
-	fmt.Print("⌚ Scene At: " )
+	fmt.Print("⌚ Scene At: ")
 	helpers.PrintSceneAt(animeResp.Docs[0].At)
 	fmt.Println("📅 Year & Season: " + color.CyanString(animeResp.Docs[0].Season))
 	fmt.Print("🍓 Is Adult: ")

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -3,6 +3,7 @@ package heplers
 import (
 	"fmt"
 	"log"
+	"math"
 
 	"github.com/fatih/color"
 )
@@ -23,6 +24,14 @@ func PrintAnimeSimilarity(similarity string) {
 	} else {
 		fmt.Println(color.RedString(similarity))
 	}
+}
+
+// PrintSceneAt is for HH:MM:SS output
+func PrintSceneAt(at float64) {
+	h := math.Floor(at / 3600)
+	m := math.Floor((at - h * 3600) / 60)
+	s := at - (h * 3600 + m * 60)
+	fmt.Println(color.YellowString("%02.f:%02.f:%02.f", h, m, s))
 }
 
 // PrintIsAdult is for colorful output

--- a/types/types.go
+++ b/types/types.go
@@ -8,6 +8,7 @@ type Response struct {
 		TitleNative  string  `json:"title_native"`
 		Similarity   float64 `json:"similarity"`
 		Episode      int     `json:"episode"`
+		At           float64 `json:"at"`
 		Season       string  `json:"season"`
 		IsAdult      bool    `json:"is_adult"`
 	} `json:"docs"`


### PR DESCRIPTION
This PR adds the time of the matching scene from the anime as `⌚ Scene At:` to the response. It also adds gif to the supported image extensions in the README.

Example:
![Capture](https://user-images.githubusercontent.com/50367411/114465430-6473e680-9be7-11eb-982d-400e4f7dbcf8.PNG)